### PR TITLE
Fix: handle up-to-date status from 

### DIFF
--- a/fox-neat-wallpaper.sh
+++ b/fox-neat-wallpaper.sh
@@ -165,9 +165,10 @@ generate_wallpaper () {
 	if [ $ret_code -eq 2 ]; then
 		# up to date
 		up_to_date=1
+	else
+		outdated="$(echo $outdated | tr --d '\n')"
+		outdated="${outdated::-1}"	# remove last semicolon to avoid marking new value when there is none
 	fi
-	outdated="$(echo $outdated | tr --d '\n')"
-	outdated="${outdated::-1}"	# remove last semicolon to avoid marking new value when there is none
 	# add get parameters
 	RENDER_URL="file://$INSTALL_PATH/render.html?"
 	RENDER_URL="${RENDER_URL}pkg_list=$all_pks"

--- a/fox-neat-wallpaper.sh
+++ b/fox-neat-wallpaper.sh
@@ -33,6 +33,7 @@ isCacheFresh () {	# test if a file in cache is up-to-date (modified in the last 
 
 cacheableResult () {	# perform command and cache the result, if the result already cached and fresh, return it
 	local ret_code
+	local COMMAND_RETURN=
 	local COMMAND="$1"
 	local CACHE_NAME="$2"
 	local CACHE_FILE_PATH="$TEMP_PATH/$CACHE_NAME"
@@ -43,7 +44,7 @@ cacheableResult () {	# perform command and cache the result, if the result alrea
 		return 0
 	fi
 	# else run command and save to cache
-	local COMMAND_RETURN="$($COMMAND)"
+	COMMAND_RETURN="$($COMMAND)"
 	ret_code=$?
 	if [ $ret_code -ne 0 ]; then
 		# don't cache on error, pass error to caller

--- a/fox-neat-wallpaper.sh
+++ b/fox-neat-wallpaper.sh
@@ -32,6 +32,7 @@ isCacheFresh () {	# test if a file in cache is up-to-date (modified in the last 
 }
 
 cacheableResult () {	# perform command and cache the result, if the result already cached and fresh, return it
+	local ret_code
 	local COMMAND="$1"
 	local CACHE_NAME="$2"
 	local CACHE_FILE_PATH="$TEMP_PATH/$CACHE_NAME"
@@ -43,6 +44,11 @@ cacheableResult () {	# perform command and cache the result, if the result alrea
 	fi
 	# else run command and save to cache
 	local COMMAND_RETURN="$($COMMAND)"
+	ret_code=$?
+	if [ $ret_code -ne 0 ]; then
+		# don't cache on error, pass error to caller
+		return $ret_code
+	fi
 	echo "$COMMAND_RETURN" > "$CACHE_FILE_PATH"
 	echo "$COMMAND_RETURN"	# return result
 	return 0

--- a/fox-neat-wallpaper.sh
+++ b/fox-neat-wallpaper.sh
@@ -124,9 +124,9 @@ get_outdated_packages () {
 	local ret_code
 	updates_output="$(checkupdates)"
 	ret_code=$?
-	if [ $ret_code -ne 0 ] && [ $ret_code -ne 2 ]; then
-		# signal there is an issue and stop wallpaper rewrite
-		return 1
+	if [ $ret_code -ne 0 ]; then
+		# will return 1 on failure or 2 when no updates are available
+		return $ret_code
 	fi
 	echo "$updates_output" | while read -r pkgname old_ver arrow new_ver; do
 		echo "$pkgname $old_ver;"

--- a/render.js
+++ b/render.js
@@ -82,6 +82,8 @@ function updateTheme(bg_color, pkg_txt_color, old_txt_color, txt_font){
 
 // generate the page
 insert_pkg_list(pkg_list)
-mark_outdated(outdated)
+if (outdated) {
+    mark_outdated(outdated)
+}
 updateTheme(background_color, package_text_color, old_text_color, text_font)
 resizeFont(img_width, img_height)


### PR DESCRIPTION
This commit fixes an issue generating wallpaper when system is up-to-date.
When up-to-date the checkupdates uses return code 2, this was not handled correctly.

Fixes https://github.com/jNullj/fox-neat-wallpaper/issues/12